### PR TITLE
Replace 'itemsLeftBehind' with 'description' in Home component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { Route, Routes } from 'react-router-dom';
 import { Home} from './components/Home';
-import Layout from './components/AppLayout';
+// import Layout from './components/AppLayout';
 
 function App() {
   return (

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -73,11 +73,7 @@ export function Home() {
               <CardFooter>
                 <ScrollArea className="h-20 w-full">
                   <div className="flex flex-wrap gap-2">
-                    {item.keyvalues.itemsLeftBehind?.map((leftItem, index) => (
-                      <Badge key={index} variant="secondary">
-                        {leftItem}
-                      </Badge>
-                    )) || <span className="text-sm text-muted-foreground">No items specified</span>}
+                    {item.keyvalues.description || <span className="text-sm text-muted-foreground">No items specified</span>}
                   </div>
                 </ScrollArea>
               </CardFooter>

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,5 +1,4 @@
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { pinataCidToUrl, useAllImages } from '../lib/requests'
 import { Package, User, Calendar, ImageIcon, CarTaxiFront, LoaderCircle } from 'lucide-react'

--- a/frontend/src/lib/requests.ts
+++ b/frontend/src/lib/requests.ts
@@ -30,8 +30,7 @@ export interface Keyvalues {
     passengerName: string;
     timestamp: string;
     
-    // TODO: below is not included from the backend but should be in the future
-    itemsLeftBehind?: string[]
+    description?: string
 }
 
 


### PR DESCRIPTION
## Summary by Sourcery

Update the Home component to use 'description' instead of 'itemsLeftBehind' for displaying item details, and comment out an unused import in App.tsx.

Enhancements:
- Replace 'itemsLeftBehind' with 'description' in the Home component for better clarity.

Chores:
- Comment out the unused import of Layout in App.tsx.